### PR TITLE
Update miniflux.service

### DIFF
--- a/miniflux/debian/miniflux.service
+++ b/miniflux/debian/miniflux.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Miniflux Feed Reader
-After=network.target
+Requires=postgresql.service
+After=network.target postgresql.service
 
 [Service]
 Type=simple

--- a/miniflux/debian/miniflux.service
+++ b/miniflux/debian/miniflux.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Miniflux Feed Reader
-Requires=postgresql.service
 After=network.target postgresql.service
 
 [Service]


### PR DESCRIPTION
Related to <https://github.com/miniflux/miniflux/issues/624#issuecomment-620642953>. At least on my f1-micro instance on the Google Compute Engine, miniflux.service is started before postgresql.service at boot. This results in miniflux failing to start after boot, but running `systemctl start miniflux` afterwards is successful.  

The change tells systemd to load postgresql.service and load miniflux after postgresql.  

This change assumes the system's postgres installation has a systemd service file, which is the case for typical Debian/Ubuntu postgres installations through apt. Some change like this may be useful on the RPM side as well.