### PR TITLE
miniflux.service: Add hardening options

### DIFF
--- a/miniflux/debian/miniflux.service
+++ b/miniflux/debian/miniflux.service
@@ -9,5 +9,15 @@ User=miniflux
 ExecStart=/usr/bin/miniflux
 Restart=always
 
+# Hardening options:
+NoNewPrivileges=true
+PrivateDevices=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+RestrictRealtime=true
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As part of defense in depth by applying the principle of least privilege, configure options provided by [systemd.exec(5)] to prevent the miniflux process from accessing or modifying files or features which are not part of its intended operation.

A brief summary of the options:

* `NoNewPrivileges=true` prevents gaining privileges through execve().
* `PrivateDevices=true` prevents access to most files in /dev.
* `ProtectControlGroups=true` read-only /sys/fs/cgroup.
* `ProtectHome=true` makes /home, /root, and /run/user inaccessible.
* `ProtectKernelModules=true` prevents module loading.
* `ProtectKernelTunables=true` makes /proc/sys and others read-only.
* `ProtectSystem=strict` / (except /dev, /proc, /sys) is read-only.
* `RestrictRealtime=true` prevents realtime task scheduling policies.

Most are documented as "recommended to enable this setting for all long-running services" in [systemd.exec(5)].  All options are supported by systemd 241 in Buster.  I had considered adding `ProtectClock`, `ProtectKernelLogs`, and `RestrictSUIDSGID`, which are supported in testing, but decided the logspam about "Unknown lvalue" probably wasn't justified for the minimal additional security.

Note: I've been using these settings on my server for a few days without issue, but if there are features I've overlooked which may require access to any of the restricted options, I'd be happy to adjust as necessary.

[systemd.exec(5)]: https://www.freedesktop.org/software/systemd/man/systemd.exec.html

Thanks for considering,
Kevin